### PR TITLE
Added a whitelist feature to skip domains for beign cloaked

### DIFF
--- a/class-wccal-product-external.php
+++ b/class-wccal-product-external.php
@@ -7,6 +7,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Wccal_Product_External extends WC_Product_External {
 	public function get_product_url( $context = 'view' ) {
+
+		// Let's fetch an array of all whitelisted domains
+		$whitelist = Wccal::get_whitelist_array();
+
+		// The actual URL
+		$url = esc_url_raw( $this->get_prop( 'product_url', $context ) );
+
+		//Find matches, return the real URL if something is whitelisted
+		$domain = parse_url($url, PHP_URL_SCHEME)."://".parse_url($url, PHP_URL_HOST);
+		if ( is_array($whitelist) && in_array($domain, $whitelist) ) return $url; 
+
 		$base = Wccal::get_affiliate_base();
 		if ( get_option( 'permalink_structure' ) ) {
 			return user_trailingslashit( home_url() . '/' . $base . '/' . $this->id );

--- a/woocommerce-cloak-affiliate-links.php
+++ b/woocommerce-cloak-affiliate-links.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'Wccal' ) ) {
 				add_settings_field( 'robots', __( 'Add Redirect Path to Robots.txt', WCCAL_DOMAIN ),
 					array( &$this, 'field_robots' ), 'wccal-options', 'general_settings' );
 			}
-			add_settings_field( 'whitelist', __( 'Do Not Cloack This URLs', WCCAL_DOMAIN ),
+			add_settings_field( 'whitelist', __( 'Do Not Cloak This URLs', WCCAL_DOMAIN ),
 				array( &$this, 'field_whitelist' ), 'wccal-options', 'general_settings' );
 		}
 

--- a/woocommerce-cloak-affiliate-links.php
+++ b/woocommerce-cloak-affiliate-links.php
@@ -252,7 +252,7 @@ if ( ! class_exists( 'Wccal' ) ) {
 		 */
 		function field_whitelist() { ?>
             <textarea id="wwcal_whitelist" name="wccal_options[whitelist]" style="min-width: 300px;"><?php echo $this->options['whitelist'] ?></textarea>
-            <p class="description"><?php _e( 'Add URLs delimited by commas (,)',
+            <p class="description"><?php _e( 'Add URLs delimited by commas (,). Be sure to add the protocol (https://), trailing slashes are ignored.',
 					WCCAL_DOMAIN ); ?></p>
 			<?php
 		}

--- a/woocommerce-cloak-affiliate-links.php
+++ b/woocommerce-cloak-affiliate-links.php
@@ -8,7 +8,7 @@ Author URI: http://www.datafeedr.com
 License: GPL v3
 Requires at least: 4.7.0
 Tested up to: 5.4
-Version: 1.0.22
+Version: 1.0.23
 
 WC requires at least: 3.0
 WC tested up to: 4.0
@@ -37,7 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define constants.
  */
-define( 'WCCAL_VERSION', '1.0.22' );
+define( 'WCCAL_VERSION', '1.0.23' );
 define( 'WCCAL_URL', plugin_dir_url( __FILE__ ) );
 define( 'WCCAL_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WCCAL_BASENAME', plugin_basename( __FILE__ ) );
@@ -112,6 +112,21 @@ if ( ! class_exists( 'Wccal' ) ) {
 			}
 
 			return $permalinks['affiliate_base'];
+		}
+
+		/**
+		 * Get the whitelist as an array.
+		 */
+		static public function get_whitelist_array() {
+			$whitelist_textarea = get_option( 'wccal_options', array() )['whitelist'];
+			
+			if ( !$whitelist_textarea ) {
+				return false;
+			}
+
+			$whitelist_array = explode(",", $whitelist_textarea);
+			array_walk($whitelist_array, function(&$item) { $item = trim(rtrim(strtolower($item), "/")); });
+			return $whitelist_array;
 		}
 
 		/**
@@ -191,6 +206,8 @@ if ( ! class_exists( 'Wccal' ) ) {
 				add_settings_field( 'robots', __( 'Add Redirect Path to Robots.txt', WCCAL_DOMAIN ),
 					array( &$this, 'field_robots' ), 'wccal-options', 'general_settings' );
 			}
+			add_settings_field( 'whitelist', __( 'Do Not Cloack This URLs', WCCAL_DOMAIN ),
+				array( &$this, 'field_whitelist' ), 'wccal-options', 'general_settings' );
 		}
 
 		/**
@@ -226,6 +243,16 @@ if ( ! class_exists( 'Wccal' ) ) {
             <p><input type="radio" value="no" name="wccal_options[robots]" <?php checked( $this->options['robots'],
 					'no', true ); ?> /> <?php _e( 'No', WCCAL_DOMAIN ); ?></p>
             <p class="description"><?php _e( 'Add the path configured on your Permalinks page to your robots.txt file to prevent any search engines from attempting to view or index that path.',
+					WCCAL_DOMAIN ); ?></p>
+			<?php
+		}
+
+		/**
+		 * Field to add URLs to the whitelist.
+		 */
+		function field_whitelist() { ?>
+            <textarea id="wwcal_whitelist" name="wccal_options[whitelist]" style="min-width: 300px;"><?php echo $this->options['whitelist'] ?></textarea>
+            <p class="description"><?php _e( 'Add URLs delimited by commas (,)',
 					WCCAL_DOMAIN ); ?></p>
 			<?php
 		}
@@ -405,6 +432,9 @@ if ( ! class_exists( 'Wccal' ) ) {
 				}
 				if ( $key == 'robots' ) {
 					$new_input['robots'] = $value;
+				}
+				if ( $key == 'whitelist' ) {
+					$new_input['whitelist'] = $value;
 				}
 			}
 


### PR DESCRIPTION
Hi! First of all, thanks for the plugin, it is working flawlessly on our project.
Recently we received a requirement from the client: we need to ignore specific URLs and return the real URL instead of the cloaked one.

So, we took the liberty of fork the project to add that functionality, and this is the first version. We added a new "whitelist" field, and any domain added there will be ignored by the plugin.

Hope the patch to be useful for the project.
Thanks!